### PR TITLE
Upgrade ceylon 1.3.2

### DIFF
--- a/source/com/acme/client/module.ceylon
+++ b/source/com/acme/client/module.ceylon
@@ -1,4 +1,4 @@
 native("js")
 module com.acme.client "1.0.0" {
-    import ceylon.interop.browser "1.2.1-1";
+    import ceylon.interop.browser "1.3.2";
 }

--- a/source/com/acme/server/module.ceylon
+++ b/source/com/acme/server/module.ceylon
@@ -1,6 +1,7 @@
 native("jvm")
 module com.acme.server "1.0.0" {
-    import ceylon.net "1.2.1";
-    import java.base "7";
-    import ceylon.interop.java "1.2.1";
+    import ceylon.http.server "1.3.2";
+    import ceylon.http.common "1.3.2";
+    import java.base "8";
+    import ceylon.interop.java "1.3.2";
 }

--- a/source/com/acme/server/run.ceylon
+++ b/source/com/acme/server/run.ceylon
@@ -1,13 +1,13 @@
-import ceylon.net.http {
+import ceylon.http.common {
     get
 }
-import ceylon.net.http.server {
+import ceylon.http.server {
     newServer,
     startsWith,
     AsynchronousEndpoint,
     Request
 }
-import ceylon.net.http.server.endpoints {
+import ceylon.http.server.endpoints {
     RepositoryEndpoint,
     serveStaticFile
 }


### PR DESCRIPTION
There are some problems with js in browser in new version.
Browser freezes after loading `ceylon.language-1.3.2.js` script.

I tried on **firefox 53.0.2(64-bit)**  and **chromium 58.0.3029.110**



